### PR TITLE
Element highlights registry

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     <syntax-highlight language="js">// JS
 import SyntaxHighlightElement from 'syntax-highlight-element';</syntax-highlight>
 
-    <syntax-highlight language="css">/* CSS */
+    <syntax-highlight language="css" contenteditable="plaintext-only">/* CSS */
 @layer syntax-highlight-element {
   syntax-highlight {
     display: inline-block;
@@ -64,6 +64,15 @@ import SyntaxHighlightElement from 'syntax-highlight-element';</syntax-highlight
 }</syntax-highlight>
 
     <script type="module" src="/src/index.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        document.addEventListener('keyup', event => {
+          if (!event.target.hasAttribute('contenteditable')) return;
+          event.target.normalize();
+          event.target.update();
+        });
+      });
+    </script>
   </body>
 </html>
 

--- a/src/index.js
+++ b/src/index.js
@@ -59,8 +59,7 @@ window[NAMESPACE] = window[NAMESPACE] || {};
   ];
 
   for (const tokenType of tokenTypes) {
-    const highlightRegistry = CSS.highlights.set(tokenType, new Highlight());
-    window[NAMESPACE].registry = highlightRegistry;
+    CSS.highlights.set(tokenType, new Highlight());
   }
 
   try {

--- a/src/syntax-highlight-element.js
+++ b/src/syntax-highlight-element.js
@@ -2,9 +2,14 @@ import { CONFIG } from './constants';
 
 export class SyntaxHighlightElement extends HTMLElement {
   #internals;
+  #highlights = new Set();
 
   get language() {
     return this.getAttribute('language') || 'plaintext';
+  }
+
+  get highlights() {
+    return this.#highlights;
   }
 
   constructor() {
@@ -20,7 +25,10 @@ export class SyntaxHighlightElement extends HTMLElement {
     this.paintTokenHighlights();
   }
 
-  paintTokenHighlights = () => {
+  /**
+   * Tokenize code and paint the token highlights.
+   */
+  paintTokenHighlights() {
     // Tokenize the text
     const lang = window.Prism.languages[this.language] || undefined;
     const tokens = window.Prism.tokenize(this.innerText, lang);
@@ -31,18 +39,36 @@ export class SyntaxHighlightElement extends HTMLElement {
     let pos = 0;
     for (const token of flatTokens) {
       if (token.type) {
+        // Optional language specific overwrite
         const tokenType = extendedTokenTypes.includes(token.type)
-          ? `${this.language}-${token.type}` // Language specific overwrite
+          ? `${this.language}-${token.type}`
           : token.type;
 
+        // Token position range
         const range = new Range();
         range.setStart(this.firstChild, pos);
         range.setEnd(this.firstChild, pos + token.length);
+
+        // Add range to tokenType highlight and update the global HighlightRegistry
         CSS.highlights.get(tokenType)?.add(range);
+
+        // Store internal reference
+        this.#highlights.add({ tokenType, range });
       }
       pos += token.length;
     }
-  };
+  }
+
+  /**
+   * Delete the highlights from the global HighlightRegistry.
+   */
+  clearTokenHighlights() {
+    for (const highlight of this.highlights) {
+      CSS.highlights.get(highlight.tokenType)?.delete(highlight.range);
+    }
+    // Clear internal references
+    this.#highlights.clear();
+  }
 }
 
 /**

--- a/src/syntax-highlight-element.js
+++ b/src/syntax-highlight-element.js
@@ -65,9 +65,17 @@ export class SyntaxHighlightElement extends HTMLElement {
   clearTokenHighlights() {
     for (const highlight of this.highlights) {
       CSS.highlights.get(highlight.tokenType)?.delete(highlight.range);
+      // Delete internal reference
+      this.#highlights.delete(highlight);
     }
-    // Clear internal references
-    this.#highlights.clear();
+  }
+
+  /**
+   * Update token highlights
+   */
+  update() {
+    this.clearTokenHighlights();
+    this.paintTokenHighlights();
   }
 }
 


### PR DESCRIPTION
Store internal highlight references to be able to delete them from the global HighlightRegistry.

**Use case**: Whenever content changes we now can clear the highlight references tokenize the new code and paint the highlights again.

- Introduce `clearTokenHighlights` method 
- Introduce `update` method - _Short form to clear and paint the token highlights_