### PR TITLE
feat: introduce "content-selector"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ HTML
 ### Attributes
 
 * `language` The code language. The default is `plaintext`. Currently suported languages `html|js|css`.
+* `content-selector` A CSS selector to specify the content element. The default is the element itself.
 
 ## Credits
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -108,6 +108,7 @@
           <h2>Attributes</h2>
           <ul>
             <li><code>language</code> The syntax language. The default is <code>plaintext</code>. Currently suported languages <code>html|js|css</code>.
+            <li><code>content-selector</code> A CSS selector to specify the content element. The default is the element itself.
           </ul>
         </article>
       </section>

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     <syntax-highlight language="js">// JS
 import SyntaxHighlightElement from 'syntax-highlight-element';</syntax-highlight>
 
-    <syntax-highlight language="css" contenteditable="plaintext-only" spellcheck="false">/* CSS */
+    <syntax-highlight language="css" content-selector="style"><style style="display: block; outline: none;" contenteditable="plaintext-only" spellcheck="false">/* CSS */
 @layer syntax-highlight-element {
   syntax-highlight {
     display: inline-block;
@@ -61,7 +61,7 @@ import SyntaxHighlightElement from 'syntax-highlight-element';</syntax-highlight
     line-height: 1.6;
     overflow-x: auto !important;
   }
-}</syntax-highlight>
+}</style></syntax-highlight>
 
     <script type="module" src="/src/index.js"></script>
     <script>
@@ -69,7 +69,7 @@ import SyntaxHighlightElement from 'syntax-highlight-element';</syntax-highlight
         document.addEventListener('keyup', event => {
           if (!event.target.hasAttribute('contenteditable')) return;
           event.target.normalize();
-          event.target.update();
+          event.target.closest('syntax-highlight').update();
         });
       });
     </script>

--- a/src/syntax-highlight-element.js
+++ b/src/syntax-highlight-element.js
@@ -60,7 +60,13 @@ export class SyntaxHighlightElement extends HTMLElement {
   static tagName = 'syntax-highlight';
 
   #internals;
+
   #highlights = new Set();
+
+  get contentElement() {
+    if (!this.hasAttribute('content-selector')) return this;
+    return this.querySelector(this.getAttribute('content-selector')) || this;
+  }
 
   get language() {
     return this.getAttribute('language') || 'plaintext';
@@ -90,7 +96,7 @@ export class SyntaxHighlightElement extends HTMLElement {
    */
   paintTokenHighlights() {
     // Tokenize the text
-    const tokens = tokenize(this.innerText, this.language);
+    const tokens = tokenize(this.contentElement.innerText, this.language);
     const extendedTokenTypes = CONFIG.extendTokenTypes?.[this.language] || [];
 
     // Paint highlights
@@ -104,8 +110,8 @@ export class SyntaxHighlightElement extends HTMLElement {
 
         // Token position range
         const range = new Range();
-        range.setStart(this.firstChild, pos);
-        range.setEnd(this.firstChild, pos + token.length);
+        range.setStart(this.contentElement.firstChild, pos);
+        range.setEnd(this.contentElement.firstChild, pos + token.length);
 
         // Add range to tokenType highlight and update the global HighlightRegistry
         CSS.highlights.get(tokenType)?.add(range);


### PR DESCRIPTION
Introduces an optional `content-selector` attribute. When defined the CSS selector is used as the content element. Useful for e.g. using a visible style tag within the syntax-highlight element to create an editor like experience.