### PR TITLE
refactor: change global namespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,8 +30,8 @@
       }
     </style>
     <script>
-      window.SyntaxHighlightElement = window.SyntaxHighlightElement || {};
-      window.SyntaxHighlightElement.config = {
+      window.she = window.she || {};
+      window.she.config = {
         // Optional: language specific token type overwrites
         languageTokens: {
           css: ['important'],

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-export const NAMESPACE = 'SyntaxHighlightElement';
+export const NAMESPACE = 'she';
 
 /**
  * @typedef Config

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import { NAMESPACE } from './constants';
 import { SyntaxHighlightElement } from './syntax-highlight-element';
-export { SyntaxHighlightElement as default };
+
+export { SyntaxHighlightElement };
+export default SyntaxHighlightElement;
 
 window[NAMESPACE] = window[NAMESPACE] || {};
-window[NAMESPACE].element = SyntaxHighlightElement.define();
+window.SyntaxHighlightElement = SyntaxHighlightElement.define();


### PR DESCRIPTION
## What changed (additional context)

- additionally to default export { SyntaxHighlightElement };

**BREAKING CHANGE:**

- change global namespace from `window.SyntaxHighlightElement` to `window.she` (`window.she.config`)
- expose the element itself with `window.SyntaxHighlightElement` instead of `window.SyntaxHighlightElement.element`