### PR TITLE
docs(site): use color-scheme-switch-element

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,15 +19,25 @@
 
     <link rel="stylesheet" href="./style.css">
     <link rel="stylesheet" href="https://unpkg.com/syntax-highlight-element@next/dist/themes/prettylights.css" data-she-theme>
+
     <script>
+      // Ensure the event listener is setup before the initial `color-scheme-switch` event gets fired.
+      document.addEventListener('color-scheme-switch', event => {
+        const colorScheme = event.target.value;
+        document.documentElement.style.setProperty('color-scheme', colorScheme);
+        event.target.querySelector('.icon use').setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", colorScheme === 'light' ? '#sun' : '#moon');
+        event.target.setAttribute('aria-label', `Switch to ${colorScheme === 'light' ? 'dark' : 'light'} color scheme`)
+      });
+
+      // Optional: language specific token type overwrites
       window.she = window.she || {};
       window.she.config = {
-        // Optional: language specific token type overwrites
         languageTokens: {
           css: ['important'],
         }
       }
     </script>
+    <script type="module" async blocking="render" src="https://unpkg.com/color-scheme-switch-element@beta/dist/color-scheme-switch-element.js"></script>
   </head>
   <body>
     <header>
@@ -35,7 +45,9 @@
         <a href="https://andreruffert.com" target="_blank"><svg xmlns="http://www.w3.org/2000/svg" width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>Made by André Ruffert</a>
         <a href="https://github.com/andreruffert/syntax-highlight-element" target="_blank" rel="noreferrer">Star on GitHub <svg xmlns="http://www.w3.org/2000/svg" width="1.2em" height="1.2em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/></svg></a>
       </div>
-      <button data-color-scheme-toggle aria-label="Toggle color scheme"><svg xmlns="http://www.w3.org/2000/svg" width="1.6em" height="1.6em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 8a2.83 2.83 0 0 0 4 4 4 4 0 1 1-4-4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.9 4.9 1.4 1.4"/><path d="m17.7 17.7 1.4 1.4"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.3 17.7-1.4 1.4"/><path d="m19.1 4.9-1.4 1.4"/></svg></button>
+      <color-scheme-switch class="button" title="Toggle light & dark color scheme">
+        <svg class="icon" width="1.2em" height="1.2em"><use xlink:href="#sun"></use></svg>
+      </color-scheme-switch>
     </header>
     <main>
       <section data-section="intro">
@@ -131,6 +143,23 @@
       <p>An <a href="https://github.com/andreruffert" target="_blank">open source</a> project by <a href="https://andreruffert.com" target="_blank">André Ruffert</a> ©.</p>
       <p>Released under the MIT License.</p>
     </footer>
+
+    <svg width="0" height="0" aria-hidden="true" hidden>
+      <symbol xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" id="sun">
+        <circle cx="12" cy="12" r="4"></circle>
+        <path d="M12 2v2"></path>
+        <path d="M12 20v2"></path>
+        <path d="m4.93 4.93 1.41 1.41"></path>
+        <path d="m17.66 17.66 1.41 1.41"></path>
+        <path d="M2 12h2"></path>
+        <path d="M20 12h2"></path>
+        <path d="m6.34 17.66-1.41 1.41"></path>
+        <path d="m19.07 4.93-1.41 1.41"></path>
+      </symbol>
+      <symbol xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" id="moon">
+        <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"></path>
+      </symbol>
+    </svg>
 
     <script type="module">
       import 'https://unpkg.com/syntax-highlight-element@next/dist/syntax-highlight-element.js';

--- a/docs/style.css
+++ b/docs/style.css
@@ -170,10 +170,11 @@
       light-dark(var(--light-button-face), var(--dark-button-face));
     padding: var(--spacing-6) var(--spacing-4);
 
-    [data-color-scheme-toggle] {
+    color-scheme-switch.button {
       padding: var(--spacing-2);
       aspect-ratio: 1;
       align-self: flex-start;
+      user-select: none;
     }
   }
 


### PR DESCRIPTION
## What changed (additional context)

Use [`color-scheme-switch-element`](https://github.com/andreruffert/color-scheme-switch-element). 
Render-blocking on purpose (async blocking="render").