### PR TITLE
feat: config languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ HTML
 
 ### Attributes
 
-* `language` The code language. The default is `plaintext`. Currently suported languages `html|js|css`.
+* `language` The code language. The default is `plaintext`. Currently suported languages `html|css|js`.
 * `content-selector` A CSS selector to specify the content element. The default is the element itself.
 
 ## Credits

--- a/docs/index.html
+++ b/docs/index.html
@@ -122,7 +122,7 @@
 
           <h2>Attributes</h2>
           <ul>
-            <li><code>language</code> The syntax language. The default is <code>plaintext</code>. Currently suported languages <code>html|js|css</code>.
+            <li><code>language</code> The syntax language. The default is <code>plaintext</code>. Currently suported languages <code>html|css|js</code>.
             <li><code>content-selector</code> A CSS selector to specify the content element. The default is the element itself.
           </ul>
         </article>

--- a/index.html
+++ b/index.html
@@ -32,9 +32,11 @@
     <script>
       window.she = window.she || {};
       window.she.config = {
+        languages: ['markup', 'css', 'javascript', 'markdown'],
         // Optional: language specific token type overwrites
         languageTokens: {
           css: ['important'],
+          md: ['title', 'list'],
         }
       }
     </script>
@@ -62,6 +64,21 @@ import SyntaxHighlightElement from 'syntax-highlight-element';</syntax-highlight
     overflow-x: auto !important;
   }
 }</style></syntax-highlight>
+
+<syntax-highlight language="md">
+  &lt;!-- ... --&gt;
+  # Heading
+
+  ## 123
+
+  __1__
+
+  1. ordered list item 1
+  2. ordered list item 2
+
+  - unordered list item 1
+  - unordered list item 2
+</syntax-highlight>
 
     <script type="module" src="/src/index.js"></script>
     <script>

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,9 +1,11 @@
 export const NAMESPACE = 'she';
+export const DEFAULT_LANGUAGES = ['markup', 'css', 'javascript'];
 
 /**
  * @typedef Config
  * @type {object}
- * @property {{ [key: string]: string[] }} languageTokens - Language specific token type overwrites.
+ * @property {string[]} languages - Prism languages.
+ * @property {{ [key: string]: string[] }} languageTokens - Language specific token types.
  */
 
 /** @type {Config} */

--- a/src/syntax-highlight-element.js
+++ b/src/syntax-highlight-element.js
@@ -1,5 +1,5 @@
-import { CONFIG } from './constants';
-import { loadPrism, setupTokenHighlights, tokenize } from './utils';
+import { CONFIG, DEFAULT_LANGUAGES } from './constants';
+import { loadPrismCore, loadPrismLanguage, setupTokenHighlights, tokenize } from './utils';
 
 const DEFAULT_TAG_NAME = 'syntax-highlight';
 
@@ -13,7 +13,8 @@ export class SyntaxHighlightElement extends HTMLElement {
     if (!registry.get(tagName)) {
       setupTokenHighlights(CONFIG?.languageTokens || {});
       try {
-        await loadPrism();
+        await loadPrismCore();
+        await loadPrismLanguage(CONFIG?.languages || DEFAULT_LANGUAGES);
         registry.define(tagName, SyntaxHighlightElement);
         return SyntaxHighlightElement;
       } catch (error) {

--- a/src/themes/prettylights.css
+++ b/src/themes/prettylights.css
@@ -152,4 +152,13 @@
   ::highlight(css-important) {
     color: var(--prettylights-keyword);
   }
+
+  /* Markdown specific tokens */
+  ::highlight(md-title) {
+    color: var(--prettylights-heading);
+  }
+
+  ::highlight(md-list) {
+    color: var(--prettylights-variable);
+  }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,13 +56,121 @@ export function setupTokenHighlights(languageTokens = {}) {
 }
 
 /**
+ * https://github.com/PrismJS/prism/blob/master/plugins/autoloader/prism-autoloader.js#L14
+ */
+const langDependencies = {
+  javascript: 'clike',
+  actionscript: 'javascript',
+  arduino: 'cpp',
+  aspnet: ['markup', 'csharp'],
+  bison: 'c',
+  c: 'clike',
+  csharp: 'clike',
+  cpp: 'c',
+  coffeescript: 'javascript',
+  crystal: 'ruby',
+  'css-extras': 'css',
+  d: 'clike',
+  dart: 'clike',
+  django: 'markup',
+  erb: ['ruby', 'markup-templating'],
+  fsharp: 'clike',
+  flow: 'javascript',
+  glsl: 'clike',
+  go: 'clike',
+  groovy: 'clike',
+  haml: 'ruby',
+  handlebars: 'markup-templating',
+  haxe: 'clike',
+  java: 'clike',
+  jolie: 'clike',
+  kotlin: 'clike',
+  less: 'css',
+  markdown: 'markup',
+  'markup-templating': 'markup',
+  n4js: 'javascript',
+  nginx: 'clike',
+  objectivec: 'c',
+  opencl: 'cpp',
+  parser: 'markup',
+  php: ['clike', 'markup-templating'],
+  'php-extras': 'php',
+  plsql: 'sql',
+  processing: 'clike',
+  protobuf: 'clike',
+  pug: 'javascript',
+  qore: 'clike',
+  jsx: ['markup', 'javascript'],
+  tsx: ['jsx', 'typescript'],
+  reason: 'clike',
+  ruby: 'clike',
+  sass: 'css',
+  scss: 'css',
+  scala: 'java',
+  smarty: 'markup-templating',
+  soy: 'markup-templating',
+  swift: 'clike',
+  tap: 'yaml',
+  textile: 'markup',
+  tt2: ['clike', 'markup-templating'],
+  twig: 'markup',
+  typescript: 'javascript',
+  vbnet: 'basic',
+  velocity: 'markup',
+  wiki: 'markup',
+  xeora: 'markup',
+  xquery: 'markup',
+};
+
+const langData = new Set();
+
+/**
+ *
+ * @param {string|Array} language
+ * @returns {Promise}
+ */
+export async function loadPrismLanguage(language) {
+  // Preserving the order is important for dependencies.
+  const languages = (Array.isArray(language) ? language : [language]).reduce((langs, lang) => {
+    const deps = langDependencies[lang]
+      ? Array.isArray(langDependencies[lang])
+        ? langDependencies[lang]
+        : [langDependencies[lang]]
+      : [];
+    langs.push(...deps, lang);
+    return langs;
+  }, []);
+
+  // Load sequentially
+  for (const lang of languages) {
+    await new Promise((resolve, reject) => {
+      if (langData.has(lang)) return resolve();
+      const script = document.createElement('script');
+      script.src = `https://unpkg.com/prismjs@1.29.0/components/prism-${lang}.min.js`;
+      script.onload = () => {
+        document.head.removeChild(script);
+        langData.add(lang);
+        resolve(lang);
+      };
+      script.onerror = (error) => {
+        document.head.removeChild(script);
+        reject(error);
+      };
+      document.head.appendChild(script);
+    });
+  }
+
+  return langData;
+}
+
+/**
  *
  * @returns {Promise}
  */
-export function loadPrism() {
+export function loadPrismCore() {
   return new Promise((resolve, reject) => {
     const script = document.createElement('script');
-    script.src = 'https://unpkg.com/prismjs@1.29.0/prism.js';
+    script.src = 'https://unpkg.com/prismjs@1.29.0/components/prism-core.min.js';
     script.dataset.manual = '';
     script.onload = resolve;
     script.onerror = reject;


### PR DESCRIPTION
## What changed (additional context)

- Reduce prism dependency to load only the core and specified languages instead of the whole prism bundle
- Improve performance by reducing 3rd party
- Adds the option to support more languages than the default ones (markup, css, js)
- Theme(prettylights) add markdown specific tokens

```diff
window.she = window.she || {};
window.she.config = {
   // Optional: configure languages you want to support for the highlight
+   languages: ['markup', 'css', 'javascript']
}
```