### PR TITLE
feat: allow opt-out of `define()`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,4 +5,7 @@ export { SyntaxHighlightElement };
 export default SyntaxHighlightElement;
 
 window[NAMESPACE] = window[NAMESPACE] || {};
-window.SyntaxHighlightElement = SyntaxHighlightElement.define();
+
+if (!new URL(import.meta.url).searchParams.has('define', 'false')) {
+  window.SyntaxHighlightElement = SyntaxHighlightElement.define();
+}


### PR DESCRIPTION
## What changed (additional context)

Introduce option to opt-out of `define()` by adding a `?define=false` query parameter to the import/script URL.

- Allows the use of a different tag name
- Run some additional configuration before definition etc.

```html
<script type="module">
  // <syntax-highlight> is not automatically defined
  import SyntaxHighlightElement from "syntax-highlight-element?define=false";

  // ...

  SyntaxHighlightElement.define("different-tag-name");
</script>
```