### PR TITLE
docs: add jsdelivr badge (monthly hits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Test status](https://img.shields.io/github/actions/workflow/status/andreruffert/syntax-highlight-element/test.yml?label=Test&logo=github&color=32A9C3&labelColor=1B3C4A)](https://github.com/andreruffert/syntax-highlight-element/actions/workflows/test.yml)
 [![npm version](https://img.shields.io/npm/v/syntax-highlight-element?color=32A9C3&labelColor=1B3C4A)](https://www.npmjs.com/package/syntax-highlight-element)
 [![npm downloads](https://img.shields.io/npm/dm/syntax-highlight-element?logo=npm&color=32A9C3&labelColor=1B3C4A)](https://www.npmjs.com/package/syntax-highlight-element)
+[![jsDelivr hits (npm)](https://img.shields.io/jsdelivr/npm/hm/syntax-highlight-element?color=32A9C3&labelColor=1B3C4A)](https://www.jsdelivr.com/package/npm/syntax-highlight-element)
 
 The code is highlighted without having to wrap a bunch of `<span>` elements around each token, thanks to [Prism][prism_github]'s tokenizer and the [CSS Custom Highlight API][MDN_CSS_Custom_Highlight_API].
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,11 +60,14 @@
         <span class="heading">&lt;syntax-highlight&gt;</span>
         <h1 class="tagline">A custom element that uses the CSS Custom Highlight API for syntax highlighting</h1>
         <p class="badges">
-          <a href="https://www.npmjs.com/package/syntax-highlight-element">
+          <a href="https://www.npmjs.com/package/syntax-highlight-element" target="_blank" rel="noreferrer">
             <img src="https://img.shields.io/npm/v/syntax-highlight-element?color=32A9C3&labelColor=1B3C4A" height="20" alt="npm version" />
           </a>
-          <a href="https://www.npmjs.com/package/syntax-highlight-element"><img src="https://img.shields.io/npm/dm/syntax-highlight-element?color=32A9C3&labelColor=1B3C4A" height="20" alt="npm downloads"></a>
-          <a href="https://github.com/andreruffert/syntax-highlight-element"><img src="https://img.shields.io/badge/source-a?logo=github&color=1B3C4A" height="20" alt="Source on GitHub"></a>
+          <a href="https://www.npmjs.com/package/syntax-highlight-element" target="_blank" rel="noreferrer"><img src="https://img.shields.io/npm/dm/syntax-highlight-element?logo=npm&color=32A9C3&labelColor=1B3C4A" height="20" alt="npm downloads"></a>
+          <a href="https://www.jsdelivr.com/package/npm/syntax-highlight-element" target="_blank" rel="noreferrer">
+            <img src="https://img.shields.io/jsdelivr/npm/hm/syntax-highlight-element?color=32A9C3&labelColor=1B3C4A" height="20" alt="jsDelivr hits (npm)">
+          </a>
+
         </p>
         <div class="copy-code-container">
           <div class="copy-code">


### PR DESCRIPTION
## What changed (additional context)

- add jsdelivr badge (monthly hits)
- docs(site): remove github source badge
- docs(site): badge links target blank, noreferrer attributes