### PR TITLE
feat: introduce `she.config.prismBaseUrl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,18 @@ Currently there are only limited [themes](https://github.com/andreruffert/syntax
 /**
  * @typedef Config
  * @type {object}
- * @property {string[]} [languages=['markup', 'css', 'javascript']] - Language grammars to highlight.
+ * @property {string} prismBaseUrl - Prism base URL to fetch the tokenizer + language data.
+ * @property {string[]} languages - Language grammars to highlight.
  * @property {{ [key: string]: string[] }} languageTokens - Language specific token types.
  */
+
 window.she = window.she || {};
+
 /** @type {Config} */
-window.she.config = {};
+window.she.config = {
+  prismBaseUrl: 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0', // Default
+  languages: ['markup', 'css', 'javascript'], // Default
+};
 ```
 
 Full list of all [languages supported](https://prismjs.com/#supported-languages) by the prism tokenizer.

--- a/docs/index.html
+++ b/docs/index.html
@@ -161,12 +161,18 @@
           <syntax-highlight language="js" id="copy-config">/**
  * @typedef Config
  * @type {object}
- * @property {string[]} [languages=['markup', 'css', 'javascript']] - Language grammars to highlight.
+ * @property {string} prismBaseUrl - Prism base URL to fetch the tokenizer + language data.
+ * @property {string[]} languages - Prism languages.
  * @property {{ [key: string]: string[] }} languageTokens - Language specific token types.
  */
+
 window.she = window.she || {};
+
 /** @type {Config} */
-window.she.config = {};</syntax-highlight>
+window.she.config = {
+  prismBaseUrl: 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0', // Default
+  languages: ['markup', 'css', 'javascript'], // Default
+};</syntax-highlight>
           <clipboard-copy for="copy-config" class="button" aria-label="Copy content">
             <svg class="icon" width="1em" height="1em" aria-hidden="true"><use xlink:href="#copy"></use></svg>
           </clipboard-copy>
@@ -178,7 +184,7 @@ window.she.config = {};</syntax-highlight>
         <h1>Examples</h1>
         <p>For more examples checkout the CodePen <a href="https://codepen.io/collection/EPYpMJ" target="_blank" rel="noreferrer">&lt;syntax-highlight&gt; collection</a>.</p>
       </section>
-      
+
       <section data-section="content">
         <h1>Credits</h1>
         <ul>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,8 @@
     <script>
       window.she = window.she || {};
       window.she.config = {
-        languages: ['markup', 'css', 'javascript', 'markdown'],
+        prismBaseUrl: 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0', // Default
+        languages: ['markup', 'css', 'javascript', 'markdown'], // Default
         // Optional: language specific token type overwrites
         languageTokens: {
           css: ['important'],

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,9 +1,11 @@
 export const NAMESPACE = 'she';
 export const DEFAULT_LANGUAGES = ['markup', 'css', 'javascript'];
+export const DEFAULT_PRISM_BASE_URL = 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0';
 
 /**
  * @typedef Config
  * @type {object}
+ * @property {string} prismBaseUrl - Prism base URL to fetch the tokenizer + language data.
  * @property {string[]} languages - Prism languages.
  * @property {{ [key: string]: string[] }} languageTokens - Language specific token types.
  */

--- a/src/syntax-highlight-element.js
+++ b/src/syntax-highlight-element.js
@@ -1,4 +1,4 @@
-import { CONFIG, DEFAULT_LANGUAGES } from './constants';
+import { CONFIG, DEFAULT_LANGUAGES, DEFAULT_PRISM_BASE_URL } from './constants';
 import { loadPrismCore, loadPrismLanguage, setupTokenHighlights, tokenize } from './utils';
 
 const DEFAULT_TAG_NAME = 'syntax-highlight';
@@ -13,8 +13,12 @@ export class SyntaxHighlightElement extends HTMLElement {
     if (!registry.get(tagName)) {
       setupTokenHighlights(CONFIG?.languageTokens || {});
       try {
-        await loadPrismCore();
-        await loadPrismLanguage(CONFIG?.languages || DEFAULT_LANGUAGES);
+        const prismBaseUrl = CONFIG?.prismBaseUrl || DEFAULT_PRISM_BASE_URL;
+        await loadPrismCore(prismBaseUrl);
+        await loadPrismLanguage({
+          baseUrl: prismBaseUrl,
+          language: CONFIG?.languages || DEFAULT_LANGUAGES,
+        });
         registry.define(tagName, SyntaxHighlightElement);
         return SyntaxHighlightElement;
       } catch (error) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,3 @@
-const PRISM_CDN_URL = 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0';
-
 /**
  * Create & register the token `Highlight`'s in the `CSS.highlights` registry.
  * This enables the use of `::highlight(tokenType)` in CSS to style them.
@@ -128,10 +126,11 @@ const langData = new Set();
 
 /**
  *
+ * @param {string} baseUrl - Prism base URL to fetch the language data
  * @param {string|Array} language
  * @returns {Promise}
  */
-export async function loadPrismLanguage(language) {
+export async function loadPrismLanguage({ baseUrl, language }) {
   // Preserving the order is important for dependencies.
   const languages = (Array.isArray(language) ? language : [language]).reduce((langs, lang) => {
     const deps = langDependencies[lang]
@@ -148,7 +147,7 @@ export async function loadPrismLanguage(language) {
     await new Promise((resolve, reject) => {
       if (langData.has(lang)) return resolve();
       const script = document.createElement('script');
-      script.src = `${PRISM_CDN_URL}/components/prism-${lang}.min.js`;
+      script.src = `${baseUrl}/components/prism-${lang}.min.js`;
       script.onload = () => {
         document.head.removeChild(script);
         langData.add(lang);
@@ -166,13 +165,13 @@ export async function loadPrismLanguage(language) {
 }
 
 /**
- *
+ * @param {string} baseUrl - Prism base URL to fetch the core (tokenizer)
  * @returns {Promise}
  */
-export function loadPrismCore() {
+export function loadPrismCore(baseUrl) {
   return new Promise((resolve, reject) => {
     const script = document.createElement('script');
-    script.src = `${PRISM_CDN_URL}/components/prism-core.min.js`;
+    script.src = `${baseUrl}/components/prism-core.min.js`;
     script.onload = resolve;
     script.onerror = reject;
     document.head.appendChild(script);


### PR DESCRIPTION
## What changed (additional context)

Introduces an optional config option to overwrite the default CDN URL for the Prism package dependencies (tokenizer + language data).

## Proof of work (screenshots / screen recordings)

<!-- Please provide before/after screenshots for any visual changes -->

```diff
/**
 * @typedef Config
 * @type {object}
+* @property {string} prismBaseUrl - Prism base URL to fetch the tokenizer + language data.
 * @property {string[]} languages - Prism languages.
 * @property {{ [key: string]: string[] }} languageTokens - Language specific token types.
 */

window.she = window.she || {};

/** @type {Config} */
window.she.config = {
+ prismBaseUrl: 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0', // Default
  languages: ['markup', 'css', 'javascript'], // Default
};
``` 

