### PR TITLE
feat: introduce `language` setter

### DIFF
--- a/src/syntax-highlight-element.js
+++ b/src/syntax-highlight-element.js
@@ -39,6 +39,10 @@ export class SyntaxHighlightElement extends HTMLElement {
     return this.getAttribute('language') || 'plaintext';
   }
 
+  set language(language) {
+    this.setAttribute('language', language);
+  }
+
   get highlights() {
     return this.#highlights;
   }


### PR DESCRIPTION
## What changed (additional context)

Introduces a `SyntaxHighlightElement.language` setter method to set the `language` programmatically.

Related: https://github.com/andreruffert/syntax-highlight-element/issues/36
