### PR TITLE
feat(loadPrismLanguage): resolve language aliases 

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       window.she = window.she || {};
       window.she.config = {
         prismBaseUrl: 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0', // Default
-        languages: ['markup', 'css', 'javascript', 'jsx', 'markdown'],
+        languages: ['html', 'css', 'js', 'jsx', 'md'],
         // Optional: language specific token type overwrites
         languageTokens: {
           css: ['important'],

--- a/src/utils.js
+++ b/src/utils.js
@@ -122,7 +122,123 @@ const langDependencies = {
   xquery: 'markup',
 };
 
+const langAliases = {
+  html: 'markup',
+  xml: 'markup',
+  svg: 'markup',
+  mathml: 'markup',
+  ssml: 'markup',
+  atom: 'markup',
+  rss: 'markup',
+  js: 'javascript',
+  g4: 'antlr4',
+  ino: 'arduino',
+  'arm-asm': 'armasm',
+  art: 'arturo',
+  adoc: 'asciidoc',
+  avs: 'avisynth',
+  avdl: 'avro-idl',
+  gawk: 'awk',
+  sh: 'bash',
+  shell: 'bash',
+  shortcode: 'bbcode',
+  rbnf: 'bnf',
+  oscript: 'bsl',
+  cs: 'csharp',
+  dotnet: 'csharp',
+  cfc: 'cfscript',
+  'cilk-c': 'cilkc',
+  'cilk-cpp': 'cilkcpp',
+  cilk: 'cilkcpp',
+  coffee: 'coffeescript',
+  conc: 'concurnas',
+  jinja2: 'django',
+  'dns-zone': 'dns-zone-file',
+  dockerfile: 'docker',
+  gv: 'dot',
+  eta: 'ejs',
+  xlsx: 'excel-formula',
+  xls: 'excel-formula',
+  gamemakerlanguage: 'gml',
+  po: 'gettext',
+  gni: 'gn',
+  ld: 'linker-script',
+  'go-mod': 'go-module',
+  hbs: 'handlebars',
+  mustache: 'handlebars',
+  hs: 'haskell',
+  idr: 'idris',
+  gitignore: 'ignore',
+  hgignore: 'ignore',
+  npmignore: 'ignore',
+  webmanifest: 'json',
+  kt: 'kotlin',
+  kts: 'kotlin',
+  kum: 'kumir',
+  tex: 'latex',
+  context: 'latex',
+  ly: 'lilypond',
+  emacs: 'lisp',
+  elisp: 'lisp',
+  'emacs-lisp': 'lisp',
+  md: 'markdown',
+  moon: 'moonscript',
+  n4jsd: 'n4js',
+  nani: 'naniscript',
+  objc: 'objectivec',
+  qasm: 'openqasm',
+  objectpascal: 'pascal',
+  px: 'pcaxis',
+  pcode: 'peoplecode',
+  plantuml: 'plant-uml',
+  pq: 'powerquery',
+  mscript: 'powerquery',
+  pbfasm: 'purebasic',
+  purs: 'purescript',
+  py: 'python',
+  qs: 'qsharp',
+  rkt: 'racket',
+  razor: 'cshtml',
+  rpy: 'renpy',
+  res: 'rescript',
+  robot: 'robotframework',
+  rb: 'ruby',
+  'sh-session': 'shell-session',
+  shellsession: 'shell-session',
+  smlnj: 'sml',
+  sol: 'solidity',
+  sln: 'solution-file',
+  rq: 'sparql',
+  sclang: 'supercollider',
+  t4: 't4-cs',
+  trickle: 'tremor',
+  troy: 'tremor',
+  trig: 'turtle',
+  ts: 'typescript',
+  tsconfig: 'typoscript',
+  uscript: 'unrealscript',
+  uc: 'unrealscript',
+  url: 'uri',
+  vb: 'visual-basic',
+  vba: 'visual-basic',
+  webidl: 'web-idl',
+  mathematica: 'wolfram',
+  nb: 'wolfram',
+  wl: 'wolfram',
+  xeoracube: 'xeora',
+  yml: 'yaml',
+};
+
 const langData = new Set();
+
+/**
+ * Resolve language aliases
+ * @param {string|Array} aliases
+ * @returns
+ */
+function resolveAliases(aliases) {
+  return Array.from(aliases || []).map((alias) => langAliases[alias] || alias);
+}
 
 /**
  * Get the direct language dependency and all of its transitive dependencies.
@@ -154,7 +270,7 @@ export function resolveLanguageDependencies(language) {
  * @returns {Promise}
  */
 export async function loadPrismLanguage({ baseUrl, language }) {
-  const languages = resolveLanguageDependencies(language);
+  const languages = resolveLanguageDependencies(resolveAliases(language));
 
   // Load sequentially
   for (const lang of languages) {


### PR DESCRIPTION
## What changed (additional context)

Enhances the `loadPrismLanguage` method to resolve language aliases e.g.

```js
window.she.config.languages = ['html'];
// Resolves to 'markup' etc.
```

Related: #38