### PR TITLE
perf(tokenizer/prism): ensure async deps loading

### DIFF
--- a/src/tokenizer/prism.js
+++ b/src/tokenizer/prism.js
@@ -298,6 +298,7 @@ export async function loadPrismLanguage({ baseUrl, language }) {
       if (langData.has(lang)) return resolve();
       const script = document.createElement('script');
       script.src = `${baseUrl}/components/prism-${lang}.min.js`;
+      script.async = true;
       script.onload = () => {
         document.head.removeChild(script);
         langData.add(lang);
@@ -322,6 +323,7 @@ export function loadPrismCore(baseUrl) {
   return new Promise((resolve, reject) => {
     const script = document.createElement('script');
     script.src = `${baseUrl}/components/prism-core.min.js`;
+    script.async = true;
     script.onload = resolve;
     script.onerror = reject;
     document.head.appendChild(script);


### PR DESCRIPTION
## What changed (additional context)

As far as I know programmatically created scripts are always asynchronous by default.

Anyhow explicitly setting the async attribute to ensure that the scripts are loaded and executed without blocking the parsing of the HTML document.

Related: #39