### PR TITLE
feat: config.setup, config.tokenize, config.tokenTypes

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,17 +32,16 @@
     <script>
       window.she = window.she || {};
       window.she.config = {
+        // Define languages to support
         languages: ['html', 'css', 'js', 'jsx', 'md'],
-        // Optional: language specific token type overwrites
+        // Language specific token type overwrites
         languageTokens: {
           css: ['important'],
           md: ['title', 'list'],
         },
-        // Optional: extend/customize tokenizer
-        // tokenizer: {
-        //   async setup() {},
-        //   tokenize: () => [],
-        // }
+        // Customize setup/tokenize method
+        // async setup() {},
+        // tokenize: () => [],
       }
     </script>
   </head>
@@ -92,58 +91,25 @@ import SyntaxHighlightElement from 'syntax-highlight-element';</syntax-highlight
 </syntax-highlight>
 
     <script type="module">
-      // /**
-      //  * Option 1. autoload - default
-      //  */
-      // import '/src/index.js'
-      import SyntaxHighlightElement from '/src/index.js'
-      // import SyntaxHighlightElement from '/src/index.js?define=false'
-      // SyntaxHighlightElement.config.languages = ['html', 'css', 'js', 'jsx', 'md'];
-      // window.SyntaxHighlightElement = await SyntaxHighlightElement.define();
+      /**
+       * Option 1. autoload - default
+       */
+      import '/src/index.js'
 
       /**
-       * Option 2. Opt out of prism autoload by manually importing prism core
+       * Option 2.a. Opt out of prism autoload by manually importing prism core
        */
-      // import 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-core.min.js'
-      // import SyntaxHighlightElement from '/src/index.js?define=false'
-
+       // import 'prismjs/components/prism-core'
       /**
-       * Option 2.a. Load lang deps manually (without dependency resolution)
+       * Option 2.b. Load lang deps manually (without dependency resolution)
        */
-      // // - CDN
-      // import 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-markup.min.js'
-      // import 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-css.min.js'
-      // import 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-clike.min.js'
-      // import 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-javascript.min.js'
-      // import 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-jsx.min.js'
-      // import 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-markdown.min.js'
-      // // - npm
       // import 'prismjs/components/prism-markup'
       // import 'prismjs/components/prism-css'
       // import 'prismjs/components/prism-clike'
       // import 'prismjs/components/prism-javascript'
       // import 'prismjs/components/prism-jsx'
       // import 'prismjs/components/prism-markdown'
-
-      /**
-       * Option 2.b. resolve language dependencies and load from URL/CDN
-       */
-      // - CDN
-      // import { loadPrismLanguage } from '/src/tokenizer/prism.js'
-      // await loadPrismLanguage({
-      //   baseUrl: 'https://unpkg.com/prismjs@1.30.0',
-      //   language: window.she.config.languages
-      // });
-      // // - npm
-      // import { resolveLanguageDependencies } from '/src/tokenizer/prism.js'
-      // const langDeps = resolveLanguageDependencies(window.she.config.languages);
-      // for await (const lang of langDeps) {
-      //   const importPath = `prismjs/components/prism-${lang}`
-      //   await import(importPath);
-      //   console.log({importPath})
-      // }
-      // // - Manually define SyntaxHighlightElement with ?define=false once all dependecies are loaded
-      // window.SyntaxHighlightElement = await SyntaxHighlightElement.define();
+      // ...
     </script>
     <script>
       document.addEventListener('DOMContentLoaded', () => {

--- a/src/config.js
+++ b/src/config.js
@@ -1,20 +1,37 @@
 import { NAMESPACE } from './constants';
-import { tokenizer as defaultTokenizer } from './tokenizer/prism';
+import { loadPrismCore, loadPrismLanguage, tokenize, tokenTypes } from './tokenizer/prism';
 
 /**
  * @typedef Config
  * @type {object}
- * @property {string[]} languages - Languages.
- * @property {{ [key: string]: string[] }} languageTokens - Language specific token types.
- * @property {object} tokenizer - Tokenizer.
+ * @property {string[]} languages - Syntax language grammars to autoload.
+ * @property {string[]} tokenTypes - Language token types.
+ * @property {{[key: string]: string[]}} languageTokens - Language specific token types.
+ * @property {function} setup - Runs before the custom element gets defined in the registry.
+ * @property {function} tokenize - Used to tokenize the text.
  */
 
 /** @type {Config} */
-export default Object.assign(
+export const config = Object.assign(
   {
     languages: ['markup', 'css', 'javascript'],
+    tokenTypes,
     languageTokens: {},
-    tokenizer: Object.assign(defaultTokenizer, window[NAMESPACE]?.config?.tokenizer || {}),
+    async setup() {
+      try {
+        if (!window.Prism) {
+          const prismBaseUrl = 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0';
+          await loadPrismCore(prismBaseUrl);
+          await loadPrismLanguage({
+            baseUrl: prismBaseUrl,
+            language: config.languages,
+          });
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    },
+    tokenize,
   },
   window[NAMESPACE]?.config || {},
 );

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,8 @@ export { SyntaxHighlightElement, setupTokenHighlights };
 export default SyntaxHighlightElement;
 
 window[NAMESPACE] = window[NAMESPACE] || {};
+window.SyntaxHighlightElement = SyntaxHighlightElement;
 
 if (!new URL(import.meta.url).searchParams.has('define', 'false')) {
-  window.SyntaxHighlightElement = await SyntaxHighlightElement.define();
+  await SyntaxHighlightElement.define();
 }

--- a/src/syntax-highlight-element.js
+++ b/src/syntax-highlight-element.js
@@ -1,4 +1,5 @@
-import config from './config';
+import { config } from './config';
+import { setupTokenHighlights } from './utils';
 
 export class SyntaxHighlightElement extends HTMLElement {
   static async define(tagName = 'syntax-highlight', registry = customElements) {
@@ -8,13 +9,12 @@ export class SyntaxHighlightElement extends HTMLElement {
     }
 
     if (!registry.get(tagName)) {
-      config?.tokenizer?.setup && (await config.tokenizer.setup(config));
+      typeof config?.setup === 'function' && (await config.setup());
+      setupTokenHighlights(config.tokenTypes, { languageTokens: config.languageTokens });
       registry.define(tagName, SyntaxHighlightElement);
       return SyntaxHighlightElement;
     }
   }
-
-  // static config = config;
 
   #internals;
   #highlights = new Set();
@@ -56,7 +56,7 @@ export class SyntaxHighlightElement extends HTMLElement {
    */
   paintTokenHighlights() {
     // Tokenize the text
-    const tokens = config.tokenizer?.tokenize(this.contentElement.innerText, this.language) || [];
+    const tokens = config.tokenize(this.contentElement.innerText, this.language) || [];
     const languageTokenTypes = config.languageTokens?.[this.language] || [];
 
     // Paint highlights

--- a/src/tokenizer/prism.js
+++ b/src/tokenizer/prism.js
@@ -1,43 +1,24 @@
-import { setupTokenHighlights } from '../utils';
-
-export const tokenizer = {
-  async setup(config) {
-    try {
-      if (!window.Prism) {
-        const prismBaseUrl = 'https://cdn.jsdelivr.net/npm/prismjs@1.30.0';
-        await loadPrismCore(prismBaseUrl);
-        await loadPrismLanguage({
-          baseUrl: prismBaseUrl,
-          language: config.languages,
-        });
-      }
-      setupTokenHighlights(tokenTypes, { languageTokens: config.languageTokens });
-    } catch (error) {
-      console.error(error);
-    }
-  },
-  /**
-   *
-   * @param {string} text - The text to tokenize.
-   * @param {string} language - The syntax language grammar.
-   * @returns {Array} - An array of flattened prismjs tokens.
-   */
-  tokenize(text, language) {
-    const lang = window.Prism.languages[language] || undefined;
-    if (!lang) {
-      console.warn(`window.Prism.languages.${language} is undefined.`);
-      return [];
-    }
-    const tokens = window.Prism.tokenize(text, lang);
-    return tokens.flatMap(getFlatToken);
-  },
-};
+/**
+ *
+ * @param {string} text - The text to tokenize.
+ * @param {string} language - The syntax language grammar.
+ * @returns {Array} - An array of flattened prismjs tokens.
+ */
+export function tokenize(text, language) {
+  const lang = window.Prism.languages[language] || undefined;
+  if (!lang) {
+    console.warn(`window.Prism.languages.${language} is undefined.`);
+    return [];
+  }
+  const tokens = window.Prism.tokenize(text, lang);
+  return tokens.flatMap(getFlatToken);
+}
 
 /**
  * Standard tokens
  * https://prismjs.com/tokens.html#standard-tokens
  */
-const tokenTypes = [
+export const tokenTypes = [
   'atrule',
   'attr-name',
   'attr-value',


### PR DESCRIPTION
## What changed (additional context)

Removes `config.tokenizer` (668a297).

New replacement for customization:
- `config.tokenTypes`
- `config.setup`
- `config.tokenize`

Related: #49